### PR TITLE
Add /help command to read docs/usage.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Now, your bot can be added to any room within your Google Workspace.
 
 - **Optimized Performance:** We prioritize a smooth experience. Before processing any message, the bot checks its size by counting its tokens. If found too lengthy, an error message suggests the user to condense their message. This ensures uninterrupted bot interactions without straining the system.
 
+- **Help On-Demand:** Have questions on how to use Chat²GPT? Just type in the `/help` command. The bot fetches content directly from the `docs/usage.md` file, ensuring users get accurate, up-to-date information.
+
 Remember, Chat²GPT is flexible, suitable for deployment on Google Cloud, FaaS (Function as a Service), or PaaS (Platform as a Service) environments, ensuring it's a perfect fit for all your Google Chat endeavors.
 
 ## 🛡️ Privacy

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,4 +20,6 @@ nav_order: 2
 
 - **Optimized Performance:** A fluid experience is paramount. The bot reviews message length by analyzing token count. If a message is overly verbose, a friendly error message nudges the user to keep it more concise. This ensures consistent, smooth interactions without overburdening the system.
 
+- **Help On-Demand:** Have questions on how to use Chat²GPT? Just type in the `/help` command. The bot fetches content directly from the `docs/usage.md` file, ensuring users get accurate, up-to-date information.
+
 Chat²GPT's versatility shines, making it apt for deployment across Google Cloud, FaaS (Function as a Service), and PaaS (Platform as a Service) platforms, cementing its place in all your Google Chat activities.

--- a/main.py
+++ b/main.py
@@ -117,6 +117,26 @@ def num_tokens_from_string(string: str) -> int:
     num_tokens = len(encoding.encode(string))
     return num_tokens
 
+
+def get_docs(doc_name: str) -> str:
+    try:
+        # Construct the file path based on the doc_name
+        file_path = f'docs/{doc_name}.md'
+        
+        # Read the specified markdown file
+        with open(file_path, 'r') as file:
+            content = file.read()
+
+        # Split the content at the "---" header line and get the second part
+        doc_content = content.split("---", 2)[-1].strip()
+
+        return doc_content
+
+    except Exception as e:
+        print(f"Error reading {doc_name} content: {str(e)}")
+        return f'Sorry, I encountered an error retrieving the {doc_name} content.'
+
+
 # Define the function for downloading voices data
 def get_voices_data():
     BASE_URL = "https://api.elevenlabs.io/v1/voices"
@@ -372,6 +392,11 @@ def handle_message(user_id, user_message):
                 })
             else:
                 return jsonify({'text': f"Sorry, I encountered an error generating the audio: {error}"})
+
+        # Check if the user input starts with /help
+        elif user_message.strip().lower() == '/help':
+            help_content = get_docs("usage")
+            return jsonify({'text': help_content})
 
         # If the message is too large, return an error message
         elif num_tokens > MAX_TOKENS_INPUT:


### PR DESCRIPTION
## Summary
Implemented a new `/help` command in the chatbot that provides users with the content of `docs/usage.md`.

## Description
Added functionality to the chatbot where users can type `/help` to get assistance. When executed, the chatbot reads from the `docs/usage.md` file and displays its content. The implementation leverages a new function, `get_docs(doc_name)`, which is designed in a generic manner to allow for future commands that might read other documentation pages.

## Related Issue(s)
#58 

## Motivation and Context
The addition of the `/help` command enhances the user experience by providing immediate assistance directly within the chat interface. The generic design of the `get_docs()` function lays the groundwork for future expansion, where other docs pages can be easily integrated into the chatbot's command set.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.