### PR TITLE
Parallelize file deletion

### DIFF
--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Delete Existing Bucket
         run: |
           if gsutil ls "gs://$GCS_BUCKET_NAME"; then
-            gsutil rm -r "gs://$GCS_BUCKET_NAME"
+            gsutil -m rm -r "gs://$GCS_BUCKET_NAME"
           fi
         env:
           GCS_BUCKET_NAME: ${{ secrets.GCS_BUCKET_NAME }}


### PR DESCRIPTION
## Summary
Implemented the `-m` flag for parallel deletion of files in GitHub Actions.

## Description
This PR introduces the use of the `-m` flag in the `gsutil rm` command within our GitHub Action. The addition of this flag is intended to speed up the deletion of multiple files, especially when there's a significant number of files to be removed from a GCS bucket. This enhancement is adaptive, ensuring efficient deletions irrespective of the number of files (many, one, or none).

## Related Issue(s)
#69 

## Motivation and Context
During our recent GitHub Action runs, we noticed that deleting files one-by-one can be time-consuming when dealing with multiple files. The Action itself suggested using the `-m` flag for efficiency. By integrating this flag, we aim to reduce the overall runtime of the GitHub Action, ensuring that file deletions are rapid and scalable.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.