### PR TITLE
Add tabbed response display

### DIFF
--- a/test_client.js
+++ b/test_client.js
@@ -13,8 +13,11 @@ $("#userForm").submit(function(e) {
         contentType: "application/json",
         success: function(response) {
             // Handle the response
-            $("#responseContainer").html("<h6>Response:</h6><pre>" + JSON.stringify(response, null, 2) + "</pre>");
-        },
+            const markdownText = response.text;
+            const htmlFormattedText = marked.parse(markdownText);
+            $("#formatted").html(htmlFormattedText);
+            $("#raw").html('<pre>' + JSON.stringify(response, null, 2) + '</pre>');
+        },              
         error: function(error) {
             // Handle the error
             $("#responseContainer").html("<h6>Response:</h6><pre>" + JSON.stringify(error, null, 2) + "</pre>");

--- a/test_interface.html
+++ b/test_interface.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <title>Chat²GPT Test</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <style>
         #responseContainer {
             overflow-y: auto;
@@ -35,7 +37,25 @@
         <button type="submit" class="btn btn-primary">Send</button>
     </form>
     <div id="responseContainer" class="mt-4">
-        <!-- The server response will be displayed here -->
+        <h4>Response:</h4> 
+        <div class="container mt-4">
+            <ul class="nav nav-tabs" id="responseTabs" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link active" id="formatted-tab" data-bs-toggle="tab" href="#formatted" role="tab" aria-controls="formatted" aria-selected="true">Formatted</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link" id="raw-tab" data-bs-toggle="tab" href="#raw" role="tab" aria-controls="raw" aria-selected="false">Raw</a>
+                </li>
+            </ul>
+            <div class="tab-content" id="myTabContent">
+                <div class="tab-pane fade show active" id="formatted" role="tabpanel" aria-labelledby="formatted-tab">
+                    <!-- Formatted markdown content goes here -->
+                </div>
+                <div class="tab-pane fade" id="raw" role="tabpanel" aria-labelledby="raw-tab">
+                    <!-- Raw markdown content goes here -->
+                </div>
+            </div>
+        </div>
     </div>
     <script src="test_client.js"></script>
 </body>


### PR DESCRIPTION
## Summary
This PR introduces a tabbed interface for displaying server responses in both formatted and raw Markdown formats. The aim is to improve user experience by offering two views for server responses.

## Description
We implemented a tabbed interface using Bootstrap 5 and jQuery to switch between "Formatted" and "Raw" views of server responses. The "Formatted" tab uses the `marked` JavaScript library to convert Markdown text to HTML, while the "Raw" tab displays the raw JSON response from the server.

Here are the major changes:
- Added Bootstrap tab structure in HTML
- Modified jQuery AJAX success handler to populate both tabs
- Included `marked` library for Markdown to HTML conversion

## Related Issue(s)
None

## Motivation and Context
The motivation behind these changes is to make it easier for users to interpret server responses in the test interface. Offering a raw JSON view allows for debugging or advanced use-cases, while the formatted Markdown view is more user-friendly and readable.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.