### PR TITLE
Update gcp-deploy.yml

### DIFF
--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -43,14 +43,13 @@ jobs:
           
       - run: |
           GCR_IMAGE_URL="gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_FUNCTION }}"
-          gcloud functions deploy ${{ secrets.GCP_FUNCTION }} \\
-            --runtime python311 \\
-            --memory 512MB \\
-            --timeout 120s \\
-            --trigger-http \\
-            --allow-unauthenticated \\
-            --entry-point process_event \\
-            --region ${{ secrets.GCP_REGION }} \\
-            --set-env-vars GCP_SA_KEY=${{ secrets.GCP_SA_KEY }},GCS_BUCKET_NAME=${{ secrets.GCS_BUCKET_NAME }},OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }},MODEL_NAME=${{ secrets.MODEL_NAME }},SYSTEM_PROMPT="${{ secrets.SYSTEM_PROMPT }}",MAX_TURNS="${{ secrets.MAX_TURNS }}",TTL="${{ secrets.TTL }}",MAX_TOKENS_INPUT="${{ secrets.MAX_TOKENS_INPUT }}",MAX_TOKENS_OUTPUT="${{ secrets.MAX_TOKENS_OUTPUT }}",TEMPERATURE="${{ secrets.TEMPERATURE }}",IMAGE_SIZE="${{ secrets.IMAGE_SIZE }}",IMAGE_STYLE="${{ secrets.IMAGE_STYLE}}",IMAGE_QUALITY="${{ secrets.IMAGE_QUALITY }}",DALLE_MODEL="${{ secrets.DALLE_MODEL }}",ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}",ELEVENLABS_MODEL_NAME="${{ secrets.ELEVENLABS_MODEL_NAME }}" \\
+          gcloud functions deploy ${{ secrets.GCP_FUNCTION }} \
+            --runtime python311 \
+            --memory 512MB \
+            --timeout 120s \
+            --trigger-http \
+            --allow-unauthenticated \
+            --entry-point process_event \
+            --region ${{ secrets.GCP_REGION }} \
+            --set-env-vars GCP_SA_KEY=${{ secrets.GCP_SA_KEY }},GCS_BUCKET_NAME=${{ secrets.GCS_BUCKET_NAME }},OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }},MODEL_NAME=${{ secrets.MODEL_NAME }},SYSTEM_PROMPT="${{ secrets.SYSTEM_PROMPT }}",MAX_TURNS="${{ secrets.MAX_TURNS }}",TTL="${{ secrets.TTL }}",MAX_TOKENS_INPUT="${{ secrets.MAX_TOKENS_INPUT }}",MAX_TOKENS_OUTPUT="${{ secrets.MAX_TOKENS_OUTPUT }}",TEMPERATURE="${{ secrets.TEMPERATURE }}",IMAGE_SIZE="${{ secrets.IMAGE_SIZE }}",IMAGE_STYLE="${{ secrets.IMAGE_STYLE}}",IMAGE_QUALITY="${{ secrets.IMAGE_QUALITY }}",DALLE_MODEL="${{ secrets.DALLE_MODEL }}",ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}",ELEVENLABS_MODEL_NAME="${{ secrets.ELEVENLABS_MODEL_NAME }}" \
             --image-url=$GCR_IMAGE_URL
-

--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -41,4 +41,16 @@ jobs:
         env:
           GCS_BUCKET_NAME: ${{ secrets.GCS_BUCKET_NAME }}
           
-      - run: gcloud functions deploy ${{ secrets.GCP_FUNCTION }} --runtime python311 --memory 512MB --timeout 120s --trigger-http --allow-unauthenticated --entry-point process_event --region ${{ secrets.GCP_REGION }} --set-env-vars GCP_SA_KEY=${{ secrets.GCP_SA_KEY }},GCS_BUCKET_NAME=${{ secrets.GCS_BUCKET_NAME }},OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }},MODEL_NAME=${{ secrets.MODEL_NAME }},SYSTEM_PROMPT="${{ secrets.SYSTEM_PROMPT }}",MAX_TURNS="${{ secrets.MAX_TURNS }}",TTL="${{ secrets.TTL }}",MAX_TOKENS_INPUT="${{ secrets.MAX_TOKENS_INPUT }}",MAX_TOKENS_OUTPUT="${{ secrets.MAX_TOKENS_OUTPUT }}",TEMPERATURE="${{ secrets.TEMPERATURE }}",IMAGE_SIZE="${{ secrets.IMAGE_SIZE }}",IMAGE_STYLE="${{ secrets.IMAGE_STYLE}}",IMAGE_QUALITY="${{ secrets.IMAGE_QUALITY }}",DALLE_MODEL="${{ secrets.DALLE_MODEL }}",ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}",ELEVENLABS_MODEL_NAME="${{ secrets.ELEVENLABS_MODEL_NAME }}"
+      - run: |
+          GCR_IMAGE_URL="gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_FUNCTION }}"
+          gcloud functions deploy ${{ secrets.GCP_FUNCTION }} \\
+            --runtime python311 \\
+            --memory 512MB \\
+            --timeout 120s \\
+            --trigger-http \\
+            --allow-unauthenticated \\
+            --entry-point process_event \\
+            --region ${{ secrets.GCP_REGION }} \\
+            --set-env-vars GCP_SA_KEY=${{ secrets.GCP_SA_KEY }},GCS_BUCKET_NAME=${{ secrets.GCS_BUCKET_NAME }},OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }},MODEL_NAME=${{ secrets.MODEL_NAME }},SYSTEM_PROMPT="${{ secrets.SYSTEM_PROMPT }}",MAX_TURNS="${{ secrets.MAX_TURNS }}",TTL="${{ secrets.TTL }}",MAX_TOKENS_INPUT="${{ secrets.MAX_TOKENS_INPUT }}",MAX_TOKENS_OUTPUT="${{ secrets.MAX_TOKENS_OUTPUT }}",TEMPERATURE="${{ secrets.TEMPERATURE }}",IMAGE_SIZE="${{ secrets.IMAGE_SIZE }}",IMAGE_STYLE="${{ secrets.IMAGE_STYLE}}",IMAGE_QUALITY="${{ secrets.IMAGE_QUALITY }}",DALLE_MODEL="${{ secrets.DALLE_MODEL }}",ELEVENLABS_API_KEY="${{ secrets.ELEVENLABS_API_KEY }}",ELEVENLABS_MODEL_NAME="${{ secrets.ELEVENLABS_MODEL_NAME }}" \\
+            --image-url=$GCR_IMAGE_URL
+


### PR DESCRIPTION
 ## Summary
This PR updates the GitHub action used for deploying a Cloud Function to include the `--image-url` flag followed by the URL of the GCR container image in the `gcloud functions deploy` command, ensuring continued use of GCR as a non-default option after January 15, 2024.

## Description
Google Cloud Functions recently announced a transition from using GCR to AR as the default storage for container images. Although this change will not take effect until at least January 15, 2024, it is recommended that users explicitly set the image registry setting back to GCR if they wish to continue using it as a non-default option.

In light of this announcement, this PR modifies the GitHub action used for deploying a Cloud Function by including the `--image-url` flag followed by the URL of the GCR container image in the `gcloud functions deploy` command. This ensures that the Cloud Function will continue to use the GCR container image even after the transition to AR takes place.

## Related Issue(s)
None.

## Motivation and Context
This change was necessary to ensure that the Cloud Function will continue to use the GCR container image even after the transition from GCR to AR takes place. This PR updates the GitHub action used for deploying a Cloud Function by including the `--image-url` flag followed by the URL of the GCR container image in the `gcloud functions deploy` command.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)